### PR TITLE
chore(docker): Add .dockerignore file and Add .secrets/ to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -574,3 +574,4 @@ $RECYCLE.BIN/
 
 # [CUSTOMIZATIONS]
 .vscode
+.secrets/


### PR DESCRIPTION
# Motivation

We need a .dockerignore file to exclude unnecessary artifacts/files/folders in our containerized application. Also want to exclude the `Google Cloud Platform Key` file (created in the pipeline to GCP deployment) in the docker build step.

# Changes

- Add .dockerignore file
- Add .secrets/ folder to .dockerignore

# Checklist

- [x] added myself as assignee
- [x] correct reviewers
- [x] descriptive PR title using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] description explains the motivation and details of the changes
- [x] tests cover my changes
- [x] documentation is updated
- [x] CI is green
- [x] breaking changes are discussed with the team and documented in the PR title `!` (e.g. `feat!: Update endpoint`)
