### PR TITLE
fix: Adapt spelling inconsistency

### DIFF
--- a/parma_mining/github/normalization_map.py
+++ b/parma_mining/github/normalization_map.py
@@ -1,6 +1,6 @@
 class GithubNormalizationMap:
     map_json = {
-        "Source": "GitHub",
+        "Source": "github",
         "Mappings": [
             {
                 "SourceField": "name",


### PR DESCRIPTION
# Motivation

Adapt spelling to github instead of GitHub to ensure normalization schema is stored correctly

# Changes

<!-- What changes have been performed? -->

# Checklist

- [ ] added myself as assignee
- [ ] correct reviewers
- [ ] descriptive PR title using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] description explains the motivation and details of the changes
- [ ] tests cover my changes
- [ ] documentation is updated
- [ ] CI is green
- [ ] breaking changes are discussed with the team and documented in the PR title `!` (e.g. `feat!: Update endpoint`)
