### PR TITLE
feat: Notify analytics backend when crawling is done

### DIFF
--- a/parma_mining/github/analytics_client.py
+++ b/parma_mining/github/analytics_client.py
@@ -21,6 +21,7 @@ class AnalyticsClient:
 
     measurement_url = urllib.parse.urljoin(analytics_base, "/source-measurement")
     feed_raw_url = urllib.parse.urljoin(analytics_base, "/feed-raw-data")
+    update_task_status_url = urllib.parse.urljoin(analytics_base, "/update-task-status")
 
     def send_post_request(self, api_endpoint, data):
         """Send a POST request to the given API endpoint with the given data."""
@@ -81,3 +82,25 @@ class AnalyticsClient:
         }
 
         return self.send_post_request(self.feed_raw_url, data)
+
+    def update_task_status(self, task_id: int, status: str, result_summary: str):
+        """Update the status of a task in the analytics service."""
+        task_information = {
+            "task_id": task_id,
+            "status": status,
+            "result_summary": result_summary,
+        }
+
+        headers = {"Content-Type": "application/json"}
+
+        response = httpx.put(
+            self.update_task_status_url, json=task_information, headers=headers
+        )
+
+        if response.status_code == HTTP_200:
+            return response.json()
+        else:
+            raise Exception(
+                f"Failed to update task status. Returned code {response.status_code},"
+                f"response: {response.text}"
+            )

--- a/parma_mining/github/api/main.py
+++ b/parma_mining/github/api/main.py
@@ -53,7 +53,7 @@ def initialize(source_id: int) -> str:
     "/companies",
     status_code=status.HTTP_200_OK,
 )
-def get_organization_details(companies: CompaniesRequest):
+def get_organization_details(companies: CompaniesRequest, task_id: int):
     """Endpoint to get detailed information about a dict of organizations."""
     for company_id, company_data in companies.companies.items():
         for data_type, handles in company_data.items():
@@ -73,11 +73,13 @@ def get_organization_details(companies: CompaniesRequest):
                 else:
                     # To be included in logging
                     print("Unsupported type error")
+
+    analytics_client.update_task_status(task_id, "success", "tbd")
     return "done"
 
 
 @app.get(
-    "/search/companies",
+    "/discover",
     response_model=list[DiscoveryModel],
     status_code=status.HTTP_200_OK,
 )


### PR DESCRIPTION
# Motivation

We need to know when crawling is done to update the status of the respective task. 

# Changes

Call update_task_status endpoint in analytics backend when all data has been retrieved. We will also send the errors to that endpoint when our Error handling concept is finalized

# Checklist

- [x] added myself as assignee
- [x] correct reviewers
- [x] descriptive PR title using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] description explains the motivation and details of the changes
- [x] tests cover my changes
- [x] my functions are fully typed
- [ ] documentation is updated
- [ ] CI is green
- [ ] breaking changes are discussed with the team and documented in the PR title `!` (e.g. `feat!: Update endpoint`)
